### PR TITLE
Correct URL to argon2 in the README and add docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Clojure library for securing user passwords using a
 * [PBKDF2](http://en.wikipedia.org/wiki/PBKDF2)
 * [Bcrypt](http://bcrypt.sourceforge.net/)
 * [scrypt](http://www.tarsnap.com/scrypt.html)
+* [argon2](http://https://github.com/phxql/argon2-jvm)
 
 [1]: http://en.wikipedia.org/wiki/Key_derivation_function
 
@@ -19,7 +20,7 @@ Add the following dependency to your `project.clj` file:
 
 ## Usage
 
-Pick an encryption algorithm, either `pbkdf2`, `bcrypt` or `scrypt`:
+Pick an encryption algorithm, either `pbkdf2`, `bcrypt`, `scrypt` or `argon2`:
 
 ```clojure
 (require '[crypto.password.<algorithm> :as password])

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Clojure library for securing user passwords using a
 * [PBKDF2](http://en.wikipedia.org/wiki/PBKDF2)
 * [Bcrypt](http://bcrypt.sourceforge.net/)
 * [scrypt](http://www.tarsnap.com/scrypt.html)
-* [argon2](http://https://github.com/phxql/argon2-jvm)
+* [argon2](https://github.com/phxql/argon2-jvm)
 
 [1]: http://en.wikipedia.org/wiki/Key_derivation_function
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src"]
+ :deps  {org.clojure/clojure     {:mvn/version "1.11.1"}
+         crypto-random           {:mvn/version "1.2.1"}
+         crypto-equality         {:mvn/version "1.0.1"}
+         commons-codec           {:mvn/version "1.15"}
+         at.favre.lib/bcrypt     {:mvn/version "0.9.0"}
+         com.lambdaworks/scrypt  {:mvn/version "1.4.0"}
+         de.mkammerer/argon2-jvm {:mvn/version "2.11"}}}

--- a/project.clj
+++ b/project.clj
@@ -8,17 +8,19 @@
                  [crypto-equality "1.0.0"]
                  [commons-codec "1.15"]
                  [at.favre.lib/bcrypt "0.9.0"]
-                 [com.lambdaworks/scrypt "1.4.0"]]
+                 [com.lambdaworks/scrypt "1.4.0"]
+                 [de.mkammerer/argon2-jvm "2.11"]]
   :plugins [[lein-codox "0.9.4"]]
   :codox
   {:output-path "codox"
    :project  {:name "Crypto-Password"}
    :metadata {:doc/format :markdown}
    :source-uri "http://github.com/weavejester/crypto-password/blob/{version}/{filepath}#L{line}"}
-  :aliases {"test-all" ["with-profile" "+1.6:+1.7:+1.8:+1.9:+1.10" "test"]}
+  :aliases {"test-all" ["with-profile" "+1.6:+1.7:+1.8:+1.9:+1.10:+1.11" "test"]}
   :profiles
   {:1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
    :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
    :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
    :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
-   :1.10 {:dependencies [[org.clojure/clojure "1.10.0"]]}})
+   :1.10 {:dependencies [[org.clojure/clojure "1.10.0"]]}
+   :1.11 {:dependencies [[org.clojure/clojure "1.11.0"]]}})

--- a/src/crypto/password/argon2.clj
+++ b/src/crypto/password/argon2.clj
@@ -1,0 +1,15 @@
+(ns crypto.password.argon2
+  (:import (de.mkammerer.argon2 Argon2 Argon2Factory Argon2Advanced)))
+
+(def argon2 (Argon2Factory/create))
+
+(defn encrypt
+  ([raw] (encrypt raw 10 65536 1))
+  ([raw iter mem parallel]
+   (.hash argon2 iter mem parallel raw)))
+
+(defn check [raw hash]
+  (.verify argon2 hash raw))
+
+(defn main [_ password]
+  (str password))

--- a/src/crypto/password/argon2.clj
+++ b/src/crypto/password/argon2.clj
@@ -4,11 +4,33 @@
 (def argon2 (Argon2Factory/create))
 
 (defn encrypt
+  "Usage:
+    (encrypt raw)
+    (encrypt raw iter mem parallel)
+
+  Parameters:
+    - raw (str): The raw string to be encrypted.
+    - iter (int): The number of iterations to perform. Defaults to 10 if not specified.
+    - mem (int): The amount of memory to use in kilobytes. Defaults to 65536 if not specified.
+    - parallel (int): The degree of parallelism to use. Defaults to 1 if not specified.
+
+  Returns:
+    A byte array containing the encrypted string."
   ([raw] (encrypt raw 10 65536 1))
   ([raw iter mem parallel]
    (.hash argon2 iter mem parallel raw)))
 
-(defn check [raw hash]
+(defn check
+  "Usage:
+    (check raw hash)
+
+  Parameters:
+    - raw (str): The raw string to check against the hash.
+    - hash (byte-array): The Argon2 password hash to check against.
+
+  Returns:
+    true if the raw string matches the hash, false otherwise."
+  [raw hash]
   (.verify argon2 hash raw))
 
 (defn main [_ password]

--- a/test/crypto/password/argon2_test.clj
+++ b/test/crypto/password/argon2_test.clj
@@ -1,0 +1,20 @@
+(ns crypto.password.argon2-test
+  (:require [clojure.test :refer [deftest are]]
+            [crypto.password.argon2 :as password]))
+
+(deftest test-passwords
+  (are [s] (password/check s (password/encrypt s))
+    "a"
+    "foo"
+    "password"
+    "Testing"
+    "Test123"
+    "ÁäñßOÔ"
+    "großpösna"
+    "Some rather long pass phrase perhaps out of a book or poem")
+
+  (are [s r] (not (password/check r (password/encrypt s)))
+    "a" "b"
+    "a" "a "
+    "aaaaa" "aaaaa\n"
+    "großpösna" "grossposna"))


### PR DESCRIPTION
# Description

Correct URL to argon2 in the README and add docstrings

# How to test

No functional modifications. All tests should pass as before.